### PR TITLE
updated the list of chat channels and added some general stuff

### DIFF
--- a/resources/community/chat_conventions.md
+++ b/resources/community/chat_conventions.md
@@ -3,7 +3,8 @@ title: Chat Channel Conventions
 description: Conventions and etiquette related to the BC Gov developer chat platform. 
 ---
 ## Chat Channel Conventions
-Below are the chat channels we manage and the intended use/etiquette around each.
+Below are the chat channels we manage and the intended use/etiquette around each. Note that this is by no means a complete list.
+If you feel there is a channel that is missing here, please let us know.
 
 We are encouraging a community/peer-to-peer support model where community members are expected to participate by sharing their experience and advice, and responding to problems and questions as they are able.  
 While the platform team will attempt to triage, and moderate discussions, the success and sustainability of the model depends to a large degree on participation from the broader community.
@@ -12,9 +13,16 @@ For more information about the the expectations involved with the community supp
 
 Note: Our current chat space is on Rocket.Chat at https://chat.pathfinder.gov.bc.ca/
 
+## General Rocketchat Etiquette
+
+If you're not sure about the purpose of a channel (aka if you're not sure if that channel is the right place to post your question), check the channel description.
+
+If you are responding directly to someone else, use the reply feature (click the little voice bubble next to the post to which you are replying).
+This helps to keep the context of your posts clear to everyone in the channel and will notify the person you're responding to.
+
 ## Channels
 
-# \#devops-sos
+### \#devops-sos
 \#devops-sos is where you should post when you have one of the issues below:
 
  * a production problem with an OpenShift-hosted app that you can't solve without external assistance from the DevOps platform team or AdvSol.
@@ -24,28 +32,28 @@ Note that normal BC Gov support channels (77000, IMB help desks, etc.) should be
 
 This channel will be monitored by the platform team and AdvSol during business hours.     
 
-# \#devops-how-to
+### \#devops-how-to
 
 \#devops-how-to is for asking *non-urgent* questions about approaches to solving problems, evaluating technical options, getting feedback on different approaches, familiarity with platform features or tools, resources/examples, etc. 
 
-# \#geows-how-to
+### \#geows-how-to
 
 \#[Geo Spatial Web Services How-to](https://chat.pathfinder.gov.bc.ca/channel/geows-how-to), this is the channel you can inquiry how to consume Province provided spatial webservices such as WMS, WFS, ArcGIS REST services with your web applications.
 
-# \#devops-alerts
+### \#devops-alerts
 
 \#devops-alerts is where the operations team will provide notices and progress notifications of upcoming or ongoing maintenance activities or incidents.  
 
-# \#labops-alerts
+### \#labops-alerts
 
 \#labops-alerts is a channel for the lab-ops team to post notifications to other lab residents and the community at large.
 Notifications about community events can be found here.
 
-# \#team-coco
+### \#team-coco
 
 Team CoCo is the Common Components team - they can be found here if you're hoping to find a component that you think might already exist, or if you have a component that you want to share with the community.
  
-# Tool Channels
+### Tool Channels
 
 There are a number of channels dedicated to community support and discussions about the use and development of specific tools.
 These channels include: (note that this is not a complete list)
@@ -57,18 +65,19 @@ These channels include: (note that this is not a complete list)
 * \#documize
 * \#bcdk
  
-# \#general
+### \#general
 
 Anything that might be of interest to the community.
 
-# \#job-postings
+### \#job-postings
 
 Learn about job opportunities in and around the BC Gov DevOps community.
 
-# \#kudos
+### \#kudos
 
 If someone (or a group of someones!) deserve your public thanks, this is the place to do it.
 
-# \#random 
+### \#random 
 
 Jokes (SFW only pls), links, and ~~cat~~ pug pictures. 'Nuff said.
+

--- a/resources/community/chat_conventions.md
+++ b/resources/community/chat_conventions.md
@@ -5,8 +5,10 @@ description: Conventions and etiquette related to the BC Gov developer chat plat
 ## Chat Channel Conventions
 Below are the chat channels we manage and the intended use/etiquette around each.
 
-As much as possible, we are encouraging a community/peer-to-peer support model where community members are expected to participate by sharing their experience and advice, and responding to problems and questions as they are able.  While the platform team will attempt to triage, and moderate discussions, the success and sustainability of the model depends to a large degree on participation from the broder community.
+We are encouraging a community/peer-to-peer support model where community members are expected to participate by sharing their experience and advice, and responding to problems and questions as they are able.  
+While the platform team will attempt to triage, and moderate discussions, the success and sustainability of the model depends to a large degree on participation from the broader community.
 
+For more information about the the expectations involved with the community support model, please see (insert link to Onboarding Outcomes here)
 
 Note: Our current chat space is on Rocket.Chat at https://chat.pathfinder.gov.bc.ca/
 
@@ -22,29 +24,51 @@ Note that normal BC Gov support channels (77000, IMB help desks, etc.) should be
 
 This channel will be monitored by the platform team and AdvSol during business hours.     
 
-
 # \#devops-how-to
 
 \#devops-how-to is for asking *non-urgent* questions about approaches to solving problems, evaluating technical options, getting feedback on different approaches, familiarity with platform features or tools, resources/examples, etc. 
-
-# \#devops-alerts
-
-\#devops-alerts is where the operations team will provide notices and progress notifications of upcoming or ongoing maintenance activities or incidents.  
-
-
-# \#devops-operations
-
-\#devops-operations is primarily for communications between the OCIO DevOps Team Services team, DXC Operations Team, and Red Hat.  On occasion, conversation with community members may get pulled into this channel (e.g. from #devops-sos) for troubleshooting, etc. but in general community members should not frequently need to post in #devops-operations.
-
- 
-# \#general
-
-Anything that might be of interest to the community.
 
 # \#geows-how-to
 
 \#[Geo Spatial Web Services How-to](https://chat.pathfinder.gov.bc.ca/channel/geows-how-to), this is the channel you can inquiry how to consume Province provided spatial webservices such as WMS, WFS, ArcGIS REST services with your web applications.
 
-#random 
+# \#devops-alerts
+
+\#devops-alerts is where the operations team will provide notices and progress notifications of upcoming or ongoing maintenance activities or incidents.  
+
+# \#labops-alerts
+
+\#labops-alerts is a channel for the lab-ops team to post notifications to other lab residents and the community at large.
+Notifications about community events can be found here.
+
+# \#team-coco
+
+Team CoCo is the Common Components team - they can be found here if you're hoping to find a component that you think might already exist, or if you have a component that you want to share with the community.
+ 
+# Tool Channels
+
+There are a number of channels dedicated to community support and discussions about the use and development of specific tools.
+These channels include: (note that this is not a complete list)
+* \#rocketchat-help
+* \#sso (this is for keycloak)
+* \#devops-artifactory
+* \#patroni
+* \#realm-o-matic
+* \#documize
+* \#bcdk
+ 
+# \#general
+
+Anything that might be of interest to the community.
+
+# \#job-postings
+
+Learn about job opportunities in and around the BC Gov DevOps community.
+
+# \#kudos
+
+If someone (or a group of someones!) deserve your public thanks, this is the place to do it.
+
+# \#random 
 
 Jokes (SFW only pls), links, and ~~cat~~ pug pictures. 'Nuff said.

--- a/resources/community/rocketchat.md
+++ b/resources/community/rocketchat.md
@@ -5,7 +5,6 @@ tags:
 - rocket chat
 - rocketchat
 - im
-- slack
 ---
 
 # Leveraging Rocket.Chat
@@ -22,20 +21,25 @@ If you do not have access, please refer to the instructions here for details: ht
 
 ## It's Community
 
-Since its inception, Rocket.Chat has been growing its user base. Since January 2020 our userbase is now over 1200! 
-
 Most chat channels are public and allow you to discover/learn about new tech, upcoming events, solutions to common problems and even more. 
+To learn more about the common channels, check out our [Chat Channel Conventions](https://developer.gov.bc.ca/topic/featured/Chat-Channel-Conventions) or go explore the options on RocketChat!
 
-For teams that work in OpenShift, it is also their primary tool to provision things like Teams in Github, projects in OpenShift, and SSO Realms.
-
-See [here](https://developer.gov.bc.ca/Community-and-Events/Chat-Channel-Conventions) for more information on the community usage.
+* Don’t know what to do? Say it out loud to our community and chances are that someone who does know will offer help.
+* Holding onto a great idea, or have a brilliant answer? Contribute it and watch the community come together to evolve it.  
 
 
 ## It's A Place To Ask Questions
 
-Over 850 users means there is a plethora of knowledge that is open for sharing. Solutions to common tech woes, 
-introductions to new tech, provoking reads in a shared article, discovery of events such as Openshift 101 and Exchange Lab Tours and more. 
-You don't need to be a Rocket.Chat veteran to contribute either :)
+A good question is more likely to get an answer - and it’s likely to get a better answer more quickly, too! To that end, you'll want to include plenty of detail:
+
+1. **What are you trying to do?** Provide full details about exactly what you're hoping to achieve. What end result are you looking for?
+2. **How are you trying to do it?** Provide full details about what you've already done to solve your problem and what tools you're using. If you're having problems logging into RocketChat, are you using IDIR or Github? Website or App? On Windows or Mac? Include all the details you can think of!
+3. **What kind of help do you want?** What is it that you're hoping the community can provide for you?
+4. **Why are you trying to do it?** Why is this important in the first place? Maybe there's another simpler way that can serve your purpose—it’s important for the community to know that, too!
+
+And make sure you're asking on the right channel! Check out [Chat Channel Conventions](https://developer.gov.bc.ca/topic/featured/Chat-Channel-Conventions) to find out more!
+
+
 
 > Case Study: The Devhub UX Survey
 The Devhub (https://developer.gov.bc.ca) Team created a survey to learn more about how users are interacting with the app.


### PR DESCRIPTION
changes include:

- moved some guidance on how to ask for help on rocketchat to the rocketchat docs instead of the onboarding one
- removed any references to the number of users on rocketchat, since that's gonna be out of date real fast!
- grabbed some of the language that bev used in the onboarding doc to move into these docs as well.
- added a bunch of the (newer?) channels on rocketchat that people should know about
- removed the reference to devops-operations (seemed weird to me to outline the existence of one specific channel that we don't really want the community to use, but let me know if you disagree about that change)