### PR TITLE
fix minor formatting typo in "migrating jenkins" resource

### DIFF
--- a/resources/aro/migrating-jenkins.md
+++ b/resources/aro/migrating-jenkins.md
@@ -18,7 +18,7 @@ This all being said, Jenkins is becoming an older and older CI/CD tool. While it
 
 ## Things to take into account before building and deploying
 
-1. Jenkins v2.235.5 now looks for builds/jobs in `/var/jenkins-data` instead of `/var/lib/jenkins/..
+1. Jenkins v2.235.5 now looks for builds/jobs in `/var/jenkins-data` instead of `/var/lib/jenkins/..`
    You will __need to modify__ any existing Jenkins DeploymentConfigs. Adjust your `volumeMounts` to match that path. 
 
 ```yaml


### PR DESCRIPTION
Hey there! I was browsing the DevHub documentation earlier and noticed a small formatting mistake, so I thought I would submit a fix:
![image](https://user-images.githubusercontent.com/5474071/105826351-814c3680-5f75-11eb-948f-b799c716b58b.png)