### PR TITLE
Update OpenShift 101 and 201 links to current instances

### DIFF
--- a/resources/community/openshift101.md
+++ b/resources/community/openshift101.md
@@ -4,17 +4,17 @@ personas:
 - Developer
 - Product Owner
 tags:
-- Openshift
-- Learning Openshift
+- OpenShift
+- Learning OpenShift
 - Developer Guide
-description: Taking Openshift 101 will provide you a highlevel overview of Openshift and how it is used in Gov. Learn about this and how you can attend a course.
+description: Taking OpenShift 101 will provide you a high level overview of OpenShift and how it is used in Gov. Learn about this and how you can attend a course.
 ---
 
-# ExchangeLab Course: Openshift 101
+# ExchangeLab Course: OpenShift 101
 
-Openshift 101 is a training course put on by the Exchange Lab (formerly CSI Lab). This course is recommended to anyone who is onboarding onto the Lab's Openshift Cluster. 
+OpenShift 101 is a training course put on by the Platform Services team. This course is recommended to anyone who is onboarding onto the OpenShift platform. 
 
-> Don't know what Openshift is? [Check out this primer](https://www.openshift.com/learn/what-is-openshift)
+> Don't know what OpenShift is? [Check out this primer](https://www.openshift.com/learn/what-is-openshift)
 
 Not only for __Developers__, this course will be of value to Product Owners, Scrum Masters, Security Analysts, Buisiness Analysts,
 any anyone else who is apart of a team that will be interacting with the platform.
@@ -29,7 +29,7 @@ This course is recommended for any individual that is being onboarded to the Exc
 
 During the course you can expect to learn many of the 'moving parts' behind OpenShift and how they can work together in your team's workflow. 
 
-The **workshop** portion of the course is a full day session, and covers the theory of working with Openshift. This workshop is aimed gives a more general background aimed at Developers, DevOps Specialists, Business Analysts and Product Owners. 
+The **workshop** portion of the course is a full day session, and covers the theory of working with OpenShift. This workshop is aimed gives a more general background aimed at Developers, DevOps Specialists, Business Analysts and Product Owners. 
 
 The **lab** part of the course is practical series of sessions aimed at technical users. The lab includes a series of touch point sessions as well as self-paced lab exercises. The lab sessions will have you working through tooling to build and deploy an application on OpenShift.
 

--- a/resources/community/openshift101.md
+++ b/resources/community/openshift101.md
@@ -39,8 +39,5 @@ For government employees there is no cost for this course. For vendors, please i
 
 ## When is the next course?
 
-Course availability changes overtime. Please sign up separately for:
-* [Openshift 101 Workshop](https://www.eventbrite.ca/e/openshift-101-workshop-tickets-311464688267) 
-* [Openshift 101 Lab](https://www.eventbrite.ca/e/openshift-lab-101-tickets-311481077287)
-
-or alternatively, check the [Devhub](https://developer.gov.bc.ca/events) for upcoming dates.
+Course availability changes over time. Please sign up at Eventbrite:
+* [OpenShift 101 Workshop & Lab](https://openshift101.eventbrite.ca/)

--- a/resources/community/openshift201.md
+++ b/resources/community/openshift201.md
@@ -3,22 +3,22 @@ resourceType: Events
 personas: 
 - Developer
 tags:
-- Openshift
-- Learning Openshift
+- OpenShift
+- Learning OpenShift
 - Developer Guide
-description: Taking Openshift 201 will provide you with more practical and hands on training that you can leverage in your day to day work
+description: Taking OpenShift 201 will provide you with more practical and hands on training that you can leverage in your day to day work
 ---
 
-# ExchangeLab Course: Openshift 201
+# ExchangeLab Course: OpenShift 201
 
-Openshift 201 is a two-day course put on by the Exchange Lab (formerly CSI Lab). This course is recommended to anyone who is onboarding onto the Lab's Openshift Cluster. 
+OpenShift 201 is a two-day course put on by the Platform Services team. This course is recommended to anyone who is onboarding onto the OpenShift platform. 
 
 ## What is it about? 
 
 OpenShift 201 outlines more practical tasks that a development team would undergo when working on their project.
 You can expect to learn:
 - Templates and codifying deployment artifacts
-- Jenkins and many things CI/CD
+- CI/CD
 - Databases and associated operational recommendations
 - Application availability and scalable design patterns
 - Granular resource and operational controls

--- a/resources/community/openshift201.md
+++ b/resources/community/openshift201.md
@@ -29,5 +29,5 @@ For government employees there is no cost for this course. For vendors, please i
 
 ## When is the next course?
 
-Course availability changes overtime. We recommend taking a look at [Eventbrite](https://www.eventbrite.ca/e/openshift-201-tickets-72320222733) or
-the [Devhub](https://developer.gov.bc.ca/events) for upcoming dates.
+Course availability changes over time. Please sign up at Eventbrite:
+* [OpenShift 201 Workshop & Lab](https://openshift201.eventbrite.ca/)


### PR DESCRIPTION
This pull request updates the [OpenShift 101](https://developer.gov.bc.ca/Beginner-Guide-to-Developing-on-the-Platform/ExchangeLab-Course:-Openshift-101) and [OpenShift 201](https://developer.gov.bc.ca/Beginner-Guide-to-Developing-on-the-Platform/ExchangeLab-Course:-Openshift-201) DevHub pages to use the current Eventbrite links. Minor updates are included for spelling, capitalization, team name, and product name. These pages will be re-thought as we re-consider the content in the [Beginner Guide to Developing on the Platform journey](https://developer.gov.bc.ca/Beginner-Guide-to-Developing-on-the-Platform/A-Guide-to-Developing-for-Gov) more broadly, but these changes should be put into production ASAP as these two pages rank at the top of Google for the keywords "openshift 101" and "openshift 201" respectively, and we want to ensure our users are able to access this training.

Tagging @mtspn for review as I don't have permissions on this repo.